### PR TITLE
yaml float handling

### DIFF
--- a/src/dbetto/catalog.py
+++ b/src/dbetto/catalog.py
@@ -246,7 +246,7 @@ class Props:
     @staticmethod
     def read_from(sources, subst_pathvar=False, trim_null=False):
         def read_impl(sources):
-            if isinstance(sources, str):
+            if isinstance(sources, (str, Path)):
                 file_name = sources
                 result = utils.load_dict(file_name)
                 if subst_pathvar:

--- a/src/dbetto/utils.py
+++ b/src/dbetto/utils.py
@@ -34,6 +34,12 @@ except ImportError:
 # values without a decimal point e.g. 5e-6 will be read as a str and not a float
 # this function will ensure that all floats are represented as floats
 def float_representer(dumper, value):
+    if str(value) == "nan":
+        return dumper.represent_scalar("tag:yaml.org,2002:float", ".nan")
+    if str(value) == "inf":
+        return dumper.represent_scalar("tag:yaml.org,2002:float", ".inf")
+    if str(value) == "-inf":
+        return dumper.represent_scalar("tag:yaml.org,2002:float", "-.inf")
     if "." not in str(value):
         return dumper.represent_scalar("tag:yaml.org,2002:float", f"{value:.1e}")
     return dumper.represent_scalar("tag:yaml.org,2002:float", str(value))
@@ -59,7 +65,7 @@ def load_dict(fname: str, ftype: str | None = None) -> dict:
         if ftype == "json":
             return json.load(f)
         if ftype == "yaml":
-            return yaml.safe_load(f, Loader=Loader)
+            return yaml.load(f, Loader=Loader)
 
         msg = f"unsupported file format {ftype}"
         raise NotImplementedError(msg)

--- a/src/dbetto/utils.py
+++ b/src/dbetto/utils.py
@@ -59,7 +59,7 @@ def load_dict(fname: str, ftype: str | None = None) -> dict:
         if ftype == "json":
             return json.load(f)
         if ftype == "yaml":
-            return yaml.safe_load(f, loader=Loader)
+            return yaml.safe_load(f, Loader=Loader)
 
         msg = f"unsupported file format {ftype}"
         raise NotImplementedError(msg)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from dbetto.catalog import Props
+from pathlib import Path
+
+def test_catalog_write(tmpdir):
+    # test write_to with float
+    test_dict = {
+                "a": 5.1e-6, # test standard float
+                "b": 5e-6,  # test float without decimal point
+                "c":float("nan"),  # test nan
+                "d":float("inf"), # test inf
+                "e":float("-inf") # test -inf
+                }
+    Props.write_to(Path(tmpdir) / "test.yaml", test_dict)
+    test_dict = Props.read_from(Path(tmpdir) / "test.yaml")
+    assert isinstance(float(test_dict["a"]))
+    assert isinstance(float(test_dict["b"]))
+    assert isinstance(float(test_dict["c"]))
+    assert isinstance(float(test_dict["d"]))
+    assert isinstance(float(test_dict["e"]))
+
+    

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
-from dbetto.catalog import Props
+
 from pathlib import Path
+
+from dbetto.catalog import Props
+
 
 def test_catalog_write(tmpdir):
     # test write_to with float
     test_dict = {
-                "a": 5.1e-6, # test standard float
-                "b": 5e-6,  # test float without decimal point
-                "c":float("nan"),  # test nan
-                "d":float("inf"), # test inf
-                "e":float("-inf") # test -inf
-                }
+        "a": 5.1e-6,  # test standard float
+        "b": 5e-6,  # test float without decimal point
+        "c": float("nan"),  # test nan
+        "d": float("inf"),  # test inf
+        "e": float("-inf"),  # test -inf
+    }
     Props.write_to(Path(tmpdir) / "test.yaml", test_dict)
     test_dict = Props.read_from(Path(tmpdir) / "test.yaml")
     assert isinstance(float(test_dict["a"]))
@@ -18,5 +21,3 @@ def test_catalog_write(tmpdir):
     assert isinstance(float(test_dict["c"]))
     assert isinstance(float(test_dict["d"]))
     assert isinstance(float(test_dict["e"]))
-
-    

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,8 +16,8 @@ def test_catalog_write(tmpdir):
     }
     Props.write_to(Path(tmpdir) / "test.yaml", test_dict)
     test_dict = Props.read_from(Path(tmpdir) / "test.yaml")
-    assert isinstance(float(test_dict["a"]))
-    assert isinstance(float(test_dict["b"]))
-    assert isinstance(float(test_dict["c"]))
-    assert isinstance(float(test_dict["d"]))
-    assert isinstance(float(test_dict["e"]))
+    assert isinstance(test_dict["a"], float)
+    assert isinstance(test_dict["b"], float)
+    assert isinstance(test_dict["c"], float)
+    assert isinstance(test_dict["d"], float)
+    assert isinstance(test_dict["e"], float)


### PR DESCRIPTION
Annoying thing in pyyaml where 5e-6 would be read in as a str instead of a float, seems to be fixed but no release yet see: https://github.com/yaml/pyyaml/pull/555 , this just adds a custom writer to add the decimal point so floats will be read correctly, maybe a better way to handle this though