### PR TITLE
Change item resolution to use absolute paths so treat symlinks as files

### DIFF
--- a/src/dbetto/textdb.py
+++ b/src/dbetto/textdb.py
@@ -273,10 +273,13 @@ class TextDB:
         item = Path(item)
 
         if item.is_absolute() and item.is_relative_to(self.__path__):
-            item = item.expanduser().resolve().relative_to(self.__path__)
+            item = item.expanduser().absolute().relative_to(self.__path__)
         elif not item.is_absolute():
             item = (
-                (self.__path__ / item).expanduser().resolve().relative_to(self.__path__)
+                (self.__path__ / item)
+                .expanduser()
+                .absolute()
+                .relative_to(self.__path__)
             )
         else:
             msg = f"{item} lies outside the database root path {self.__path__!s}"

--- a/tests/test_textdb.py
+++ b/tests/test_textdb.py
@@ -338,3 +338,20 @@ def test_hidden():
 
     assert isinstance(jdb.dir2, TextDB)
     assert getattr(jdb.dir2, "__hidden__", False) is True
+
+def test_symlink(tmp_path):
+    # Create a file outside the db root
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    ext_file = external_dir / "ext_file.yaml"
+    ext_file.write_text("data: 99\n")
+
+    # Create a db directory with a symlink pointing to the external file
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    symlink = db_dir / "linked.yaml"
+    symlink.symlink_to(ext_file)
+
+    # TextDB should read the symlinked file without following it to resolve paths
+    jdb = TextDB(db_dir)
+    assert jdb["linked"]["data"] == 99

--- a/tests/test_textdb.py
+++ b/tests/test_textdb.py
@@ -339,6 +339,7 @@ def test_hidden():
     assert isinstance(jdb.dir2, TextDB)
     assert getattr(jdb.dir2, "__hidden__", False) is True
 
+
 def test_symlink(tmp_path):
     # Create a file outside the db root
     external_dir = tmp_path / "external"


### PR DESCRIPTION
This makes dataflow-overrides readable with dbetto