### PR TITLE
feat: add load_attrs_dict() utility function

### DIFF
--- a/src/dbetto/__init__.py
+++ b/src/dbetto/__init__.py
@@ -20,11 +20,14 @@ from .attrsdict import AttrsDict
 from .catalog import Props
 from .textdb import TextDB
 from .time import str_to_datetime
+from .utils import load_attrs_dict, load_dict
 
 __all__ = [
     "AttrsDict",
     "Props",
     "TextDB",
     "__version__",
+    "load_attrs_dict",
+    "load_dict",
     "str_to_datetime",
 ]

--- a/src/dbetto/utils.py
+++ b/src/dbetto/utils.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import yaml
 
+from .attrsdict import AttrsDict
+
 log = logging.getLogger(__name__)
 
 __file_extensions__ = {"json": [".json"], "yaml": [".yaml", ".yml"]}
@@ -69,6 +71,11 @@ def load_dict(fname: str, ftype: str | None = None) -> dict:
 
         msg = f"unsupported file format {ftype}"
         raise NotImplementedError(msg)
+
+
+def load_attrs_dict(fname: str, ftype: str | None = None) -> AttrsDict:
+    """Load a text file as an :class:`.AttrsDict`."""
+    return AttrsDict(load_dict(fname, ftype))
 
 
 def write_dict(obj: dict, fname: str, ftype: str | None = None) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from dbetto import AttrsDict
 from dbetto.catalog import Props
+from dbetto.utils import load_attrs_dict, load_dict
 
 
 def test_catalog_write(tmpdir):
@@ -21,3 +23,12 @@ def test_catalog_write(tmpdir):
     assert isinstance(test_dict["c"], float)
     assert isinstance(test_dict["d"], float)
     assert isinstance(test_dict["e"], float)
+
+
+def test_load_attrs_dict():
+    testdb = Path(__file__).parent / "testdb"
+    for fname in (testdb / "file1.json", testdb / "file2.yaml"):
+        result = load_attrs_dict(fname)
+        assert isinstance(result, AttrsDict)
+        plain = load_dict(fname)
+        assert result == plain


### PR DESCRIPTION
Add `load_attrs_dict()` as a standalone utility function that loads a JSON or YAML file directly as an `AttrsDict`, rather than modifying `load_dict()` with an extra argument. Both functions are now exported from the top-level `dbetto` namespace.