### PR TITLE
fix: rename validity `system` argument to `category`

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "dbetto-tools",
+  "description": "Claude Code plugins for working with dbetto text databases.",
+  "owner": { "name": "Luigi Pertoldi", "email": "gipert@pm.me" },
+  "plugins": [
+    {
+      "name": "inspect-textdb",
+      "source": "./.claude/skills/inspect-textdb",
+      "description": "Load, query, and verify dbetto TextDB/Catalog/Props metadata (JSON/YAML text databases and time-validity files)."
+    }
+  ]
+}

--- a/.claude/skills/inspect-textdb/.claude-plugin/plugin.json
+++ b/.claude/skills/inspect-textdb/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "inspect-textdb",
+  "description": "Load, query, and verify dbetto TextDB/Catalog/Props metadata (JSON/YAML text databases and time-validity files).",
+  "version": "1.0.0",
+  "author": { "name": "Luigi Pertoldi", "email": "gipert@pm.me" }
+}

--- a/.claude/skills/inspect-textdb/SKILL.md
+++ b/.claude/skills/inspect-textdb/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: inspect-textdb
+description: >-
+  Load, query, and verify text-based databases (JSON/YAML files scattered across
+  a directory tree, plus time-validity files) with the dbetto Python API:
+  TextDB, AttrsDict, Catalog, Props, and the time utilities. Use this whenever
+  someone points at a folder of JSON/YAML data or config and wants to read a
+  value, walk the tree, resolve which files are valid at a given timestamp,
+  remap/group entries by an inner key (e.g. a channel/detector map), merge
+  cascading property files, or confirm that an edit to the data or to a
+  validity.* file produces the intended behavior. Reach for it even when the
+  user does not say "dbetto" by name: a data/config directory, a validity.yaml,
+  channel maps, LEGEND metadata, "what applies on <date>", "did my validity
+  change work", or attribute-style access to nested JSON/YAML are all triggers.
+---
+
+# Inspecting a dbetto text database
+
+dbetto treats a directory of JSON/YAML files as a database. Directories, files,
+and the keys inside a file all sit at the same semantic level, so you can walk
+from the top folder down to a leaf value with one uniform syntax. In memory
+every mapping becomes an `AttrsDict` (a `dict` you can also access with dot
+notation). This skill is the map of what the API can do and which entry point
+fits each question, including how to check that a change to the data behaves.
+
+## Orient first
+
+Before writing code, look at the data. The right API call depends on the shape
+on disk, so check it:
+
+- `find <dir> -maxdepth 2 -name '*.json' -o -name '*.yaml' -o -name '*.yml'` to
+  see the file layout.
+- Look for a `validity.yaml` / `validity.json` / `validity.jsonl` in a
+  directory: its presence means the data is time-versioned and you should query
+  it with `.on(timestamp)` rather than reading a fixed file.
+- Peek at one file to learn whether the top level is a mapping (`{...}`) or a
+  list (`[...]`), and whether entries carry an inner id worth remapping on (e.g.
+  `daq.rawid`, `name`).
+
+Everything is importable from the top package:
+
+```python
+from dbetto import TextDB, AttrsDict, Props, load_dict, load_attrs_dict, str_to_datetime
+```
+
+## Load a database
+
+```python
+from dbetto import TextDB
+
+db = TextDB("/path/to/data")  # scans the tree immediately
+```
+
+- `lazy=True` skips the initial filesystem scan and caches files as you touch
+  them. Cheap for huge trees, but `.map()`, `.group()`, iteration, and `.keys()`
+  need a populated store, so call `db.scan()` first if you use them.
+  `lazy="auto"` is lazy except in an interactive session.
+- `hidden=True` includes dot-files/dot-dirs (ignored by default).
+- To read a single file without a whole database: `load_dict(path)` returns a
+  plain `dict`/`list`; `load_attrs_dict(path)` returns an `AttrsDict`. Both
+  infer JSON vs YAML from the extension.
+
+## Access files and values
+
+Directories resolve to nested `TextDB` objects; files resolve to `AttrsDict` (or
+a `list`). The extension is optional and path-style keys work:
+
+```python
+db["dir1"]["file1.json"]  # dict-style, explicit extension
+db["dir1"]["file1"]  # extension omitted
+db["dir1/file1"]  # filesystem-path key
+db.dir1.file1.value  # attribute-style (tab-completes in IPython)
+```
+
+Attribute access only works for keys that are valid Python identifiers; for
+anything else (dashes, leading digits, dots) use `db["odd-key"]`. Missing keys
+raise `AttributeError` / `FileNotFoundError` / `ValueError`, so let those
+surface rather than guessing at names.
+
+A useful convenience inside data files: the string `$_` expands to the absolute
+path of the directory containing the file when the file is loaded, so entries
+can reference sibling paths.
+
+## Query by time validity
+
+If a directory holds a `validity.*` file, `db.on()` returns the merged content
+of every file that is in force at a timestamp:
+
+```python
+from datetime import datetime
+
+db.on(datetime(2023, 1, 10, 9, 53, 0)).value  # datetime object
+db.on("20230110T095300Z").value  # YYYYmmddTHHMMSSZ string
+db.on("20230110T095300Z", category="cal")  # restrict to a category/system
+db.on("20230110T095300Z", pattern=r"geds/.*")  # keep only matching filenames
+```
+
+The result is a read-only `AttrsDict` built by cascading the applicable files in
+order (later files override earlier keys). Timestamps are treated as UTC. If you
+need a `datetime` from the string form, use `str_to_datetime(...)`.
+
+The `category` argument selects a data-taking category (the `category` field in
+the validity file, e.g. `phy`, `cal`, `lar`); a category with no entries of its
+own falls back to the `all` entries, and a category that _does_ have its own
+entries is resolved from those alone (it is not merged with `all`). Note the
+naming: the validity-file key, the `.on()`/`.valid_for()` argument, and
+`Catalog.get_files` all use `category`. (`system=` is still accepted as a
+deprecated alias for `category` and emits a `DeprecationWarning`.)
+
+The validity-file format (entries with `valid_from`, `category`, `apply`, and
+`mode` = append/remove/replace/reset), the legacy JSONL variant, and the
+lower-level `Catalog` API (`Catalog.read_from`, `.valid_for`,
+`Catalog.get_files`) are documented in
+[references/validity-files.md](references/validity-files.md). Read it whenever
+you need to author a validity file, debug why a timestamp resolves to the wrong
+files, or work with the catalog without a `TextDB`.
+
+## Remap and group entries
+
+When a file (or directory) maps arbitrary keys to records that each carry a
+meaningful inner id, `.map()` re-keys by that id and `.group()` buckets by a
+non-unique one. Both accept dotted paths to reach nested ids.
+
+```python
+chmap = db["channelmap.yaml"]  # {name -> record}
+chmap.map("daq.rawid")[1104003]  # re-key by the DAQ id (must be unique)
+chmap.group("electronics.cc4.id")["C3"]  # bucket detectors sharing a card
+chmap.group("electronics.cc4.id")["C3"].map("name").keys()  # chain them
+```
+
+`.map()` raises if the id is not unique; use `.group()` (or
+`.map(label, unique=False)`) when duplicates are expected. Results are cached
+and share the read-only flag of the source. `TextDB` forwards
+`.map()`/`.group()` to its store, so `db.map(...)` works too (populate a lazy db
+with `scan()` first).
+
+## Merge cascading property files (Props)
+
+`Props` handles layered config where later sources override earlier ones, key by
+key and recursing into nested dicts:
+
+```python
+from dbetto import Props
+
+merged = Props.read_from([base_path, override_path])  # list = cascade, last wins
+Props.add_to(a, b)  # merge b onto a (b wins; insertion order of a preserved)
+Props.subst_vars(d, var_values={"_": some_dir})  # expand $_ / $var templates
+Props.trim_null(d)  # drop keys whose value is None
+```
+
+`read_from` takes `subst_pathvar=True` (expand `$_` to each file's parent dir)
+and `trim_null=True`. On overlap, `props_b` wins but the original key order of
+`props_a` is preserved, which matters when downstream steps reference earlier
+keys by name.
+
+## Verify a data or validity-file change
+
+A common reason to reach for dbetto is to confirm that an edit to the data (a
+value, a file added to `apply`, a new `valid_from`) actually changes what a
+query returns, and only where intended. Load the data and exercise the query
+directly rather than reasoning about the files by eye.
+
+- **Reload after editing on disk.** `TextDB` caches each file as it reads it, so
+  a live instance will not see your edit. Construct a fresh `TextDB(dir)`, or
+  call `db.reset()` (re-scans if non-lazy), before re-querying.
+- **Probe the boundaries.** For a validity change, resolve `.on()` at timestamps
+  just before and just after each relevant `valid_from` and check that the file
+  set / values flip exactly there and nowhere else:
+
+  ```python
+  db = TextDB(dir)
+  before = db.on("20230101T235959Z")  # last second of the old regime
+  after = db.on("20230102T000000Z")  # first second of the new one
+  ```
+
+- **Diff old vs new.** Resolve the same timestamps against the pre-change and
+  post-change data (e.g. two git checkouts, or a copy of the folder) and compare
+  `to_dict()` outputs to see precisely what moved, instead of trusting that only
+  the intended keys changed.
+- **Inspect the low-level resolution** when `.on()` surprises you:
+  `Catalog.read_from(path).valid_for(ts, category)` returns just the filename
+  list and `.entries` shows the fully expanded per-category timeline (see
+  [references/validity-files.md](references/validity-files.md)). This isolates
+  whether a wrong result comes from the validity logic or from the file
+  contents.
+- **Catch broken invariants.** If downstream code relies on `.map("some.id")`,
+  run it after the edit: a newly duplicated id raises `RuntimeError`, which is
+  exactly the regression you want to surface early.
+
+For a check you will repeat, wrap these as assertions in a short script or a
+pytest under `tests/`, so the expected behavior is captured rather than
+eyeballed once.
+
+## AttrsDict notes
+
+- `d.to_dict()` returns a plain nested `dict`/`list` (handy for JSON dumps,
+  diffing, or passing to code that does strict `type(x) is dict` checks).
+- `.on()` results are read-only; mutating them raises. `deepcopy` first if you
+  need to edit, rather than flipping `__readonly__` back.
+- The same object may be returned for several timestamps when it is valid across
+  all of them, so an in-place edit would leak across queries: copy first.
+
+## Quick recipes
+
+- "What is `X` in file `Y`?" -> `TextDB(dir).Y.X` (or `load_attrs_dict`).
+- "Which files/values apply on `<date>`?" -> `TextDB(dir).on("<ts>")`.
+- "Did my validity edit work?" -> reload `TextDB`, `.on()` straddling the
+  `valid_from` boundary, compare `to_dict()` before/after.
+- "Give me detector `1104003`'s record" -> `chmap.map("daq.rawid")[1104003]`.
+- "All channels on card `C3`" -> `chmap.group("electronics.cc4.id")["C3"]`.
+- "Layer these config files" -> `Props.read_from([...], trim_null=True)`.
+
+When you have run a query, show the actual returned structure (or a trimmed view
+via `to_dict()`); do not paraphrase values you have not printed.

--- a/.claude/skills/inspect-textdb/references/validity-files.md
+++ b/.claude/skills/inspect-textdb/references/validity-files.md
@@ -1,0 +1,109 @@
+# Validity files and the Catalog API
+
+A validity file maps time points (and optionally data-taking "systems") to the
+set of metadata files that are in force from then on. dbetto reads it to answer
+"which files apply at timestamp T?". `TextDB.on()` is the high-level front door;
+`Catalog` is the underlying machinery you can use standalone.
+
+Official spec:
+https://legend-exp.github.io/legend-data-format-specs/dev/metadata/#Specifying-metadata-validity-in-time-(and-system)
+
+## File format (YAML/JSON)
+
+A list of entries, each with:
+
+- `valid_from` (required): timestamp string `YYYYmmddTHHMMSSZ` (UTC).
+- `apply` (required): a filename or list of filenames, relative to the directory
+  holding the validity file.
+- `category` (optional, default `all`): the system/category this entry applies
+  to, a string or list of strings (e.g. `all`, `phy`, `cal`, `lar`).
+- `mode` (optional): how this entry's `apply` combines with the running set for
+  its category. Default is `append` for YAML/JSON.
+
+```yaml
+- valid_from: 20230101T000000Z
+  category: all
+  apply:
+    - file1.json # reset (first entry is always a reset)
+
+- valid_from: 20230102T000000Z
+  category: all
+  mode: append
+  apply:
+    - file2.json # now {file1, file2} are in force
+```
+
+## Modes
+
+The catalog keeps a running file list per category, ordered by `valid_from`.
+Each entry transforms the previous list:
+
+- `reset`: the new list _is_ `apply`. The first entry of a category is always
+  treated as a reset regardless of the written mode.
+- `append`: previous list + `apply`.
+- `remove`: previous list with every filename in `apply` removed.
+- `replace`: `apply` must be exactly `[old, new]`; swaps `old` for `new`.
+
+Resolution at timestamp T (`Catalog.valid_for`) takes the most recent entry
+whose `valid_from <= T` via a bisect. If the requested category has no matching
+entry, it falls back to the `all` category; if still nothing, it raises unless
+`allow_none=True`. A category that has its own entries is resolved from those
+alone (not merged with `all`).
+
+Duplicate `valid_from` values within a category raise (use a single `reset`
+entry instead) unless duplicate checking is suppressed.
+
+## Legacy JSONL
+
+The old format is one JSON object per line (`.jsonl`). Two behavioral
+differences are baked in for backward compatibility:
+
+- default `mode` is `reset` (not `append`);
+- duplicate-timestamp checking is suppressed.
+
+```jsonl
+{"valid_from":"20220628T221955Z","category":"all","apply":["file7.json"]}
+{"valid_from":"20220629T221955Z","category":"all","apply":["file8.json"]}
+```
+
+## Catalog API (no TextDB needed)
+
+```python
+from dbetto.catalog import Catalog
+
+cat = Catalog.read_from("validity.yaml")  # build from a file
+cat.valid_for("20230102T120000Z")  # -> list of filenames for 'all'
+cat.valid_for("20230102T120000Z", category="cal", allow_none=True)
+Catalog.get_files("validity.yaml", "20230102T120000Z", "all")  # one-shot helper
+
+cat.write_to("out.yaml")  # serialize back; re-derives compact modes
+```
+
+- `Catalog.read_from(path)` picks the right defaults from the extension
+  (`.jsonl` -> reset/suppress-duplicates; otherwise append).
+- `Catalog.build_catalog(stream, mode_default=..., suppress_duplicate_check=...)`
+  builds from an already-loaded list/generator instead of a path.
+- `valid_for(timestamp, category="all", allow_none=False)` returns the in-force
+  filename list; timestamp is a string or `datetime`. (`system=` is a deprecated
+  alias for `category`.)
+- `write_to` collapses the internal per-category entries back into the compact
+  append/remove/replace/reset representation and writes YAML/JSON (or JSONL if
+  the target extension is `.jsonl`).
+
+## PropsStream
+
+`PropsStream.get(value)` normalizes a validity source (path, list, or generator)
+into a generator of entry dicts, sorting file-backed sources by `valid_from`.
+You rarely call it directly; `Catalog.build_catalog` uses it.
+
+## Debugging "wrong files at timestamp T"
+
+1. Confirm which validity file `.on()` picked: it looks for `validity` +
+   `.yaml/.yml/.json/.jsonl` in the directory and warns if several exist.
+2. Rebuild the catalog explicitly and inspect: `Catalog.read_from(path).entries`
+   is a `{category: [Entry(valid_from_unix, [files]), ...]}` dict, sorted in
+   time.
+3. Remember category fallback: a query for `cal` that finds no `cal` entries
+   silently uses `all`.
+4. Check mode accumulation: an unexpected file usually means an earlier `append`
+   left it in the running set; a `remove`/`replace` may be needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,10 @@
-# OpenAI Codex
-
-## Testing requirements
-
-Install all required dependencies for tests, linting and docs building by using
-the `all` optional dependency group defined in `pyproject.toml`. With
-python-pip, you would need to run `pip install -e '.[all]'`.
-
-Make sure the `bin` directory where executables are installed by pip is added to
-the `PATH` environment variable.
-
-There are many dependencies, so it could take a while to install them. Please
-wait, do not interrupt the install process.
-
 ## Testing
 
-run `nox -s docs --non-interactive` to build docs. `nox -s lint` for linting.
-`nox -s tests` for tests.
+- `nox -s tests` runs the test suite.
+- `nox -s docs --non-interactive` builds the docs.
+- `nox -s lint` runs the pre-commit hooks; `nox -s pylint` runs PyLint (CI runs
+  both). Bare `nox` runs lint + pylint + tests. Note: mypy is manual-stage and
+  not run by `nox -s lint`.
 
 ## Submitting a Pull Request
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/dbetto/catalog.py
+++ b/src/dbetto/catalog.py
@@ -19,6 +19,7 @@ import collections
 import json
 import logging
 import types
+import warnings
 from collections import namedtuple
 from collections.abc import Generator
 from pathlib import Path
@@ -80,9 +81,9 @@ class Catalog(namedtuple("Catalog", ["entries"])):
         def asdict(self):
             return {"valid_from": self.valid_from, "apply": self.file}
 
-        def save_format(self, system: str = "all"):
+        def save_format(self, category: str = "all"):
             dic = self.asdict()
-            dic["category"] = system
+            dic["category"] = category
             dic["valid_from"] = time.datetime_to_str(dic["valid_from"])
             return dic
 
@@ -110,27 +111,27 @@ class Catalog(namedtuple("Catalog", ["entries"])):
         entries = {}
         for props in PropsStream.get(propstream):
             timestamp = props["valid_from"]
-            system = props.get("category", "all")
-            if not isinstance(system, list):
-                system = [system]
+            categories = props.get("category", "all")
+            if not isinstance(categories, list):
+                categories = [categories]
             file_key = props["apply"]
             if isinstance(file_key, str):
                 file_key = [file_key]
-            for syst in system:
-                if syst not in entries:
-                    entries[syst] = []
+            for category in categories:
+                if category not in entries:
+                    entries[category] = []
                 mode = props.get("mode", mode_default)
-                mode = "reset" if len(entries[syst]) == 0 else mode
+                mode = "reset" if len(entries[category]) == 0 else mode
                 if mode == "reset":
                     new = file_key
                 elif mode == "append":
-                    new = entries[syst][-1].file.copy() + file_key
+                    new = entries[category][-1].file.copy() + file_key
                 elif mode == "remove":
-                    new = entries[syst][-1].file.copy()
+                    new = entries[category][-1].file.copy()
                     for file in file_key:
                         new.remove(file)
                 elif mode == "replace":
-                    new = entries[syst][-1].file.copy()
+                    new = entries[category][-1].file.copy()
                     if len(file_key) != 2:
                         msg = f"Invalid number of elements in replace mode: {len(file_key)}"
                         raise ValueError(msg)
@@ -142,14 +143,14 @@ class Catalog(namedtuple("Catalog", ["entries"])):
 
                 if (
                     time.unix_time(timestamp)
-                    in [entry.valid_from for entry in entries[syst]]
+                    in [entry.valid_from for entry in entries[category]]
                     and suppress_duplicate_check is False
                 ):
                     msg = f"Duplicate timestamp: {timestamp}, use reset mode instead with a single entry"
                     raise ValueError(msg)
-                entries[syst].append(Catalog.Entry(time.unix_time(timestamp), new))
-        for system, value in entries.items():
-            entries[system] = sorted(value, key=lambda entry: entry.valid_from)
+                entries[category].append(Catalog.Entry(time.unix_time(timestamp), new))
+        for category, value in entries.items():
+            entries[category] = sorted(value, key=lambda entry: entry.valid_from)
         return Catalog(entries)
 
     @staticmethod
@@ -163,31 +164,48 @@ class Catalog(namedtuple("Catalog", ["entries"])):
         )  # difference between old jsonl and new yaml is just the change of default mode from append to reset
 
     def valid_for(
-        self, timestamp: str, system: str = "all", allow_none: bool = False
+        self,
+        timestamp: str,
+        category: str = "all",
+        allow_none: bool = False,
+        *,
+        system: str | None = None,
     ) -> list:
-        """Get the valid entries for a given timestamp and system"""
-        if system in self.entries:
-            valid_from = [entry.valid_from for entry in self.entries[system]]
+        """Get the valid entries for a given timestamp and category.
+
+        .. deprecated::
+            The `system` argument is deprecated, use `category` instead.
+        """
+        if system is not None:
+            warnings.warn(
+                "the 'system' argument is deprecated, use 'category' instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            category = system
+
+        if category in self.entries:
+            valid_from = [entry.valid_from for entry in self.entries[category]]
             pos = bisect.bisect_right(valid_from, time.unix_time(timestamp))
             if pos > 0:
-                return self.entries[system][pos - 1].file
+                return self.entries[category][pos - 1].file
 
-            if system != "all":
-                return self.valid_for(timestamp, system="all", allow_none=allow_none)
+            if category != "all":
+                return self.valid_for(timestamp, "all", allow_none=allow_none)
 
             if allow_none:
                 return None
 
-            msg = f"No valid entries found for timestamp: {timestamp}, system: {system}"
+            msg = f"No valid entries found for timestamp: {timestamp}, category: {category}"
             raise RuntimeError(msg)
 
-        if system != "all":
-            return self.valid_for(timestamp, system="all", allow_none=allow_none)
+        if category != "all":
+            return self.valid_for(timestamp, "all", allow_none=allow_none)
 
         if allow_none:
             return None
 
-        msg = f"No entries found for system: {system}"
+        msg = f"No entries found for category: {category}"
         raise RuntimeError(msg)
 
     @staticmethod
@@ -200,9 +218,9 @@ class Catalog(namedtuple("Catalog", ["entries"])):
 
     def get_dict_format(self) -> list:
         write_list = []
-        for system, entries in self.entries.items():
+        for category, entries in self.entries.items():
             for entry in entries:
-                write_list.append(entry.save_format(system))
+                write_list.append(entry.save_format(category))
         current_files = []
         for entry in write_list:
             files = entry["apply"].copy()
@@ -233,9 +251,9 @@ class Catalog(namedtuple("Catalog", ["entries"])):
         ext = Path(file_name).suffix
         if ext == ".jsonl":
             with Path(file_name).open("w", encoding="utf-8") as file:
-                for system, entries in self.entries.items():
+                for category, entries in self.entries.items():
                     for entry in entries:
-                        file.write(json.dumps(entry.save_format(system)) + "\n")
+                        file.write(json.dumps(entry.save_format(category)) + "\n")
         else:
             utils.write_dict(self.get_dict_format(), file_name)
 

--- a/src/dbetto/catalog.py
+++ b/src/dbetto/catalog.py
@@ -31,6 +31,25 @@ from .attrsdict import AttrsDict
 log = logging.getLogger(__name__)
 
 
+def _resolve_category_alias(
+    category: str, system: str | None, stacklevel: int = 3
+) -> str:
+    """Resolve the deprecated `system` keyword alias to `category`.
+
+    Emits a :class:`DeprecationWarning` and returns `system` when it was passed,
+    otherwise returns `category` unchanged. `stacklevel` should point the warning
+    at the original caller (default assumes one intermediate frame).
+    """
+    if system is not None:
+        warnings.warn(
+            "the 'system' argument is deprecated, use 'category' instead",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+        return system
+    return category
+
+
 class PropsStream:
     """Simple class to control loading of validity files"""
 
@@ -176,13 +195,7 @@ class Catalog(namedtuple("Catalog", ["entries"])):
         .. deprecated::
             The `system` argument is deprecated, use `category` instead.
         """
-        if system is not None:
-            warnings.warn(
-                "the 'system' argument is deprecated, use 'category' instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            category = system
+        category = _resolve_category_alias(category, system)
 
         if category in self.entries:
             valid_from = [entry.valid_from for entry in self.entries[category]]

--- a/src/dbetto/textdb.py
+++ b/src/dbetto/textdb.py
@@ -19,6 +19,7 @@ import json
 import logging
 import re
 import sys
+import warnings
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
@@ -158,9 +159,14 @@ class TextDB:
         return self.__store__.items()
 
     def on(
-        self, timestamp: str | datetime, pattern: str | None = None, system: str = "all"
+        self,
+        timestamp: str | datetime,
+        pattern: str | None = None,
+        category: str = "all",
+        *,
+        system: str | None = None,
     ) -> AttrsDict | list:
-        """Query database in `time[, file pattern, system]`.
+        """Query database in `time[, file pattern, category]`.
 
         A (only one) valid validity file (YAML, JSON, JSONL and other file
         types supported) must exist in the directory to specify a validity
@@ -185,9 +191,20 @@ class TextDB:
             pattern ``YYYYmmddTHHMMSSZ``.
         pattern
             query by filename pattern.
+        category
+            query only a data taking "category"/"system" (e.g. 'all', 'phy',
+            'cal', 'lar', ...)
         system
-            query only a data taking "system" (e.g. 'all', 'phy', 'cal', 'lar', ...)
+            deprecated alias for `category`.
         """
+        if system is not None:
+            warnings.warn(
+                "the 'system' argument is deprecated, use 'category' instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            category = system
+
         _extensions = [*list(self.__extensions__), ".jsonl"]
         validity_file = None
         for ext in _extensions:
@@ -207,7 +224,7 @@ class TextDB:
             raise RuntimeError(msg)
 
         # parse validity file and return requested files
-        file_list = Catalog.get_files(str(validity_file), timestamp, system)
+        file_list = Catalog.get_files(str(validity_file), timestamp, category)
 
         # select only files matching pattern, if specified
         if pattern is not None:

--- a/src/dbetto/textdb.py
+++ b/src/dbetto/textdb.py
@@ -19,7 +19,6 @@ import json
 import logging
 import re
 import sys
-import warnings
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
@@ -28,7 +27,7 @@ import yaml
 
 from . import utils
 from .attrsdict import AttrsDict
-from .catalog import Catalog, Props
+from .catalog import Catalog, Props, _resolve_category_alias
 
 log = logging.getLogger(__name__)
 
@@ -197,13 +196,7 @@ class TextDB:
         system
             deprecated alias for `category`.
         """
-        if system is not None:
-            warnings.warn(
-                "the 'system' argument is deprecated, use 'category' instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            category = system
+        category = _resolve_category_alias(category, system)
 
         _extensions = [*list(self.__extensions__), ".jsonl"]
         validity_file = None

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -110,8 +110,8 @@ def test_catalog_valid_for():
         {"apply": ["file2.json"], "valid_from": "20220629T221955Z"},
     )
     catalog = Catalog.get(catalog)
-    # test system falls back to default
-    assert catalog.valid_for("20220628T221955Z", system="test") == ["file1.json"]
+    # test category falls back to default
+    assert catalog.valid_for("20220628T221955Z", category="test") == ["file1.json"]
     # test allow none
     assert catalog.valid_for("20220627T233502Z", allow_none=True) is None
     # no entries for timestamp
@@ -122,12 +122,12 @@ def test_catalog_valid_for():
         {"apply": ["file2.json"], "valid_from": "20220629T221955Z", "category": "test"},
     )
     catalog = Catalog.get(catalog)
-    # test system not present
+    # test category not present
     with pytest.raises(RuntimeError):
-        catalog.valid_for("20220628T221955Z", system="test2")
-    # test system not present and allow_none
+        catalog.valid_for("20220628T221955Z", category="test2")
+    # test category not present and allow_none
     assert (
-        catalog.valid_for("20220628T221955Z", system="test2", allow_none=True) is None
+        catalog.valid_for("20220628T221955Z", category="test2", allow_none=True) is None
     )
     # test fallback to default for earlier timestamps
     catalog = (
@@ -135,7 +135,11 @@ def test_catalog_valid_for():
         {"apply": ["file2.json"], "valid_from": "20220630T221955Z", "category": "test"},
     )
     catalog = Catalog.get(catalog)
-    assert catalog.valid_for("20220629T221955Z", system="test") == ["file1.json"]
+    assert catalog.valid_for("20220629T221955Z", category="test") == ["file1.json"]
+
+    # the deprecated `system` alias still works but warns
+    with pytest.deprecated_call():
+        assert catalog.valid_for("20220629T221955Z", system="test") == ["file1.json"]
 
 
 def test_catalog_write(tmpdir):

--- a/tests/test_textdb.py
+++ b/tests/test_textdb.py
@@ -213,8 +213,8 @@ def test_time_validity():
     # test replace functionality
     assert jdb["dir1"].on("20230105T120000Z")["data"] == 1
     # test lists of categories
-    assert jdb.dir1.on("20230106T000001Z", system="cat1").data == 3
-    assert jdb.dir1.on("20230106T000001Z", system="cat2").data == 3
+    assert jdb.dir1.on("20230106T000001Z", category="cat1").data == 3
+    assert jdb.dir1.on("20230106T000001Z", category="cat2").data == 3
     # directory with no .yml
     with pytest.raises(RuntimeError):
         jdb["dir1"]["dir2"].on("20230101T000001Z")
@@ -232,8 +232,12 @@ def test_time_validity():
     assert jdb.dir1.on(tstamp).data == 1
     assert jdb.dir1.on(tstamp, r"^file3.*", "all").data == 1
 
-    assert jdb.dir1.on(tstamp, system="phy").data == 1
-    assert jdb.dir1.on(tstamp, system="cal").data == 1
+    assert jdb.dir1.on(tstamp, category="phy").data == 1
+    assert jdb.dir1.on(tstamp, category="cal").data == 1
+
+    # the deprecated `system` alias still works but warns
+    with pytest.deprecated_call():
+        assert jdb.dir1.on(tstamp, system="phy").data == 1
 
     # test that nested structures are not irreversibly modified by on
     read1 = deepcopy(jdb.dir4.on("20230101T000000Z"))


### PR DESCRIPTION
The validity axis (`phy`/`cal`/`lar`/`all`…) was referred to by two different names depending on where you looked in `catalog.py`, even though it is a single concept. The serialized field and `Catalog.get_files` use `category`, but `TextDB.on` and `Catalog.valid_for` exposed the same thing as `system`, and the internal `build_catalog`/`save_format`/`write_to` code oscillated between the two.

They are genuinely the same axis, not two filters: `build_catalog` reads the label only from the file `category` field (`system = props.get("category", "all")`) and keys `self.entries` by it, while `valid_for` looks its `system` argument up in that same dict. `"system"` is never read from the data anywhere; it existed purely as a parameter/variable name.

This PR makes the whole validity API speak one name, `category` (the name users already see in their files and in `get_files`):

- `TextDB.on(..., category="all")` and `Catalog.valid_for(..., category="all")`.
- Internal `system`/`syst` variables in `build_catalog`, `get_dict_format`, `write_to`, and `Entry.save_format` renamed to `category`.
- Tests migrated to `category=`.

## Backward compatibility

`system=` is kept as a deprecated keyword-only alias that emits a `DeprecationWarning`; positional callers are unaffected since the argument position is unchanged. Downstream code (e.g. pylegendmeta, legend-dataflow) keeps working, but should migrate `system=` → `category=`; the alias can be removed in a future major release.

New tests cover the alias via `pytest.deprecated_call()`.

## Notes

Unrelated to this axis, detector/channel-map records may carry a data field literally named `system` (e.g. `system: geds`); `Catalog` never touches it, so it is untouched here.